### PR TITLE
Set address mode explicitly to 7 in SFPU code and surround LOAD/STORE with CAST for Int32

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -23,7 +23,7 @@ inline void _add_int32_(const int iterations, const uint dst_offset) {
     // Output is int32
 
     // Modifies LOAD/STORE to work with INT32 2's complement, however
-    // due to a bug in Blackhole this has no effect and format is INT32 sign-magnitude.
+    // in Blackhole this has no effect and format remains INT32 sign-magnitude.
     constexpr auto INSTR_MOD_LOAD_STORE = InstrModLoadStore::INT32_2S_COMP;
 
     // LOAD/STORE have the value in INT sign magnitude format and SFPU needs it as 2's complement.

--- a/common/inc/sfpu/ckernel_sfpu_add_int32.h
+++ b/common/inc/sfpu/ckernel_sfpu_add_int32.h
@@ -21,17 +21,37 @@ inline void _add_int32_(const int iterations, const uint dst_offset) {
     // Operand A is input1 (int32)
     // Operand B is input2 (int32)
     // Output is int32
+
+    // Modifies LOAD/STORE to work with INT32 2's complement, however
+    // due to a bug in Blackhole this has no effect and format is INT32 sign-magnitude.
+    constexpr auto INSTR_MOD_LOAD_STORE = InstrModLoadStore::INT32_2S_COMP;
+
+    // LOAD/STORE have the value in INT sign magnitude format and SFPU needs it as 2's complement.
+    constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // operand A - int32
-        TTI_SFPLOAD(0, 12, 3, 0);
+        TTI_SFPLOAD(0 /*lreg*/, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0 /*dest_reg_addr */);
+        TTI_SFPCAST(0 /*lreg*/, 2 /*ldest*/, INSTR_MOD_CAST);
+        // Required after cast due to a bug in Blackhole RTL.
+        TTI_SFPSETSGN(0 /* imm */, 2 /*lreg_c*/, 0 /*ldest*/, 0 /*imod*/);
+
         // operand B - int32
-        TT_SFPLOAD(1, 12, 3, dst_offset * 64);
-        TTI_SFPIADD(0, 1, 0, 4);
+        TT_SFPLOAD(1 /*lreg*/, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, dst_offset * 64);
+        TTI_SFPCAST(1 /*lreg*/, 2 /*ldest*/, INSTR_MOD_CAST);
+        // Required after cast due to a bug in Blackhole RTL.
+        TTI_SFPSETSGN(0 /* imm */, 2 /*lreg_c*/, 1 /*ldest*/ , 0 /*imod*/);
+
+        TTI_SFPIADD(0 /*imm*/, 1 /*lreg_c*/, 0 /*lreg_dest*/, 4 /*imod*/);
         // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
         TTI_NOP;
+
         // LREG_0 -> dest as int32
-        TTI_SFPSTORE(0, 12, 3, 0);
+        TTI_SFPCAST(0 /*lreg*/, 1 /*ldest*/, INSTR_MOD_CAST);
+        // Required after cast due to a bug in Blackhole RTL.
+        TTI_SFPSETSGN (0 /* imm */, 1 /*lreg_c*/, 0 /*ldest*/, 0 /*imod*/);
+        TTI_SFPSTORE(0, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0);
         dst_reg++;
     }
 }

--- a/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -24,9 +24,9 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     {
         //vFloat val = dst_reg[0];
         //dst_reg[0] = float_to_fp16a(val, 0);
-        TTI_SFPLOAD(0, 0, 3, 0);
+        TTI_SFPLOAD(0, 0, ADDR_MOD_7, 0);
         TTI_SFP_STOCH_RND(0,0,0,0,0,8);
-        TTI_SFPSTORE(0,1,3,0);
+        TTI_SFPSTORE(0,1,ADDR_MOD_7,0);
         dst_reg++;
     }
 }

--- a/common/inc/sfpu/ckernel_sfpu_exp.h
+++ b/common/inc/sfpu/ckernel_sfpu_exp.h
@@ -95,21 +95,21 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
         //  ROUND  : unused
         //  SIMPLE : SWAP the larger value of y and -88.5 into the LREG
         //  STORE  : store the sanitized value back to dest
-        TTI_SFPLOADMACRO(4, 0, 3, 0);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[0] for loaded value - Dest offset  0 is targeting the even columns for rows   3: 0 
+        TTI_SFPLOADMACRO(4, 0, ADDR_MOD_7, 0);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[0] for loaded value - Dest offset  0 is targeting the even columns for rows   3: 0
         TTI_SFPNOP;                     // NOP is necessary because the SWAP operation takes 2 cycles and unfortunately is not pipelined
-        TTI_SFPLOADMACRO(5, 0, 3, 2);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[1] for loaded value - Dest offset  2 is targeting the odd  columns for rows   3: 0
+        TTI_SFPLOADMACRO(5, 0, ADDR_MOD_7, 2);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[1] for loaded value - Dest offset  2 is targeting the odd  columns for rows   3: 0
         TTI_SFPNOP;
-        TTI_SFPLOADMACRO(6, 0, 3, 4);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[2] for loaded value - Dest offset  4 is targeting the even columns for rows   7: 4
+        TTI_SFPLOADMACRO(6, 0, ADDR_MOD_7, 4);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[2] for loaded value - Dest offset  4 is targeting the even columns for rows   7: 4
         TTI_SFPNOP;
-        TTI_SFPLOADMACRO(7, 0, 3, 6);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[3] for loaded value - Dest offset  6 is targeting the odd  columns for rows   7: 4
+        TTI_SFPLOADMACRO(7, 0, ADDR_MOD_7, 6);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[3] for loaded value - Dest offset  6 is targeting the odd  columns for rows   7: 4
         TTI_SFPNOP;
-        TTI_SFPLOADMACRO(4, 0, 3, 8);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[0] for loaded value - Dest offset  8 is targeting the even columns for rows  11: 8
+        TTI_SFPLOADMACRO(4, 0, ADDR_MOD_7, 8);   // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[0] for loaded value - Dest offset  8 is targeting the even columns for rows  11: 8
         TTI_SFPNOP;
-        TTI_SFPLOADMACRO(5, 0, 3, 10);  // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[1] for loaded value - Dest offset 10 is targeting the even columns for rows  11: 8
+        TTI_SFPLOADMACRO(5, 0, ADDR_MOD_7, 10);  // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[1] for loaded value - Dest offset 10 is targeting the even columns for rows  11: 8
         TTI_SFPNOP;
-        TTI_SFPLOADMACRO(6, 0, 3, 12);  // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[2] for loaded value - Dest offset 12 is targeting the odd  columns for rows  15:12
+        TTI_SFPLOADMACRO(6, 0, ADDR_MOD_7, 12);  // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[2] for loaded value - Dest offset 12 is targeting the odd  columns for rows  15:12
         TTI_SFPNOP;
-        TTI_SFPLOADMACRO(7, 0, 3, 14);  // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[3] for loaded value - Dest offset 14 is targeting the even columns for rows  15:12
+        TTI_SFPLOADMACRO(7, 0, ADDR_MOD_7, 14);  // MACRO Sequence Register 1: LD, SWAP, STORE - uses LREG[3] for loaded value - Dest offset 14 is targeting the even columns for rows  15:12
         // NOP not needed in this spot because the next LoadMacro is a computational macro which doesn't immediately use the SIMPLE unit
 
         // Macro Sequence Register 0 configured to read back in the sanitized values and calculate the approximate exponential value
@@ -118,20 +118,20 @@ void _calculate_exponential_(const int iterations, uint16_t exp_base_scale_facto
         //  ROUND  : convert the MAD result from FP32 to a 16-bit unsigned integer using stochastic rounding
         //  SIMPLE : shift the 16-bit integer to the left by 15 bits to place the MSB of the computed value into the MSB of the exponent bits of the fp32 format
         //  STORE  : store the shifted value back to dest
-        TTI_SFPLOADMACRO(0, 0, 3, 0);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[0] for loading and intermediate results - Dest offset  0 is targeting the even columns for rows   3: 0
-        TTI_SFPLOADMACRO(1, 0, 3, 2);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[1] for loading and intermediate results - Dest offset  2 is targeting the odd  columns for rows   3: 0
-        TTI_SFPLOADMACRO(2, 0, 3, 4);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[2] for loading and intermediate results - Dest offset  4 is targeting the even columns for rows   7: 4
-        TTI_SFPLOADMACRO(3, 0, 3, 6);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[3] for loading and intermediate results - Dest offset  6 is targeting the odd  columns for rows   7: 4
-        TTI_SFPLOADMACRO(0, 0, 3, 8);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[0] for loading and intermediate results - Dest offset  8 is targeting the even columns for rows  11: 8
-        TTI_SFPLOADMACRO(1, 0, 3, 10);  // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[1] for loading and intermediate results - Dest offset 10 is targeting the even columns for rows  11: 8
-        TTI_SFPLOADMACRO(2, 0, 3, 12);  // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[2] for loading and intermediate results - Dest offset 12 is targeting the odd  columns for rows  15:12
-        TTI_SFPLOADMACRO(3, 0, 3, 14);  // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[3] for loading and intermediate results - Dest offset 14 is targeting the even columns for rows  15:12
+        TTI_SFPLOADMACRO(0, 0, ADDR_MOD_7, 0);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[0] for loading and intermediate results - Dest offset  0 is targeting the even columns for rows   3: 0
+        TTI_SFPLOADMACRO(1, 0, ADDR_MOD_7, 2);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[1] for loading and intermediate results - Dest offset  2 is targeting the odd  columns for rows   3: 0
+        TTI_SFPLOADMACRO(2, 0, ADDR_MOD_7, 4);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[2] for loading and intermediate results - Dest offset  4 is targeting the even columns for rows   7: 4
+        TTI_SFPLOADMACRO(3, 0, ADDR_MOD_7, 6);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[3] for loading and intermediate results - Dest offset  6 is targeting the odd  columns for rows   7: 4
+        TTI_SFPLOADMACRO(0, 0, ADDR_MOD_7, 8);   // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[0] for loading and intermediate results - Dest offset  8 is targeting the even columns for rows  11: 8
+        TTI_SFPLOADMACRO(1, 0, ADDR_MOD_7, 10);  // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[1] for loading and intermediate results - Dest offset 10 is targeting the even columns for rows  11: 8
+        TTI_SFPLOADMACRO(2, 0, ADDR_MOD_7, 12);  // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[2] for loading and intermediate results - Dest offset 12 is targeting the odd  columns for rows  15:12
+        TTI_SFPLOADMACRO(3, 0, ADDR_MOD_7, 14);  // MACRO Sequence Register 0: LD, MAD, ROUND, SHIFT and STORE - uses LREG[3] for loading and intermediate results - Dest offset 14 is targeting the even columns for rows  15:12
         // NOP needed to allow time for the final Computation Loadmacro to complete before returning to the Sanitation Loadmacro at the top for the next iteration
         //  - to be completely safe, use 3 NOP; in practice 1 seems to be enough, probably because the overhead of the DEST INCRW stuff introduces 2 cycles of delay
-        TTI_SFPNOP;                     
+        TTI_SFPNOP;
         // TTI_SFPNOP;
         // TTI_SFPNOP;
-    
+
     } else {
         // Unroll 8 best for approx, unroll 0 for precise, compiler figures this out
         for (int d = 0; d < iterations; d++)
@@ -199,40 +199,40 @@ inline void _init_exponential_()
         //          LREG[12] = A     =    369.329925537109375 = 0x43b8aa3b
         //          LREG[13] = (B-C) =  32500.818359375       = 0x46fde9a3
 
-        TTI_SFPLOADI(0, 0xA, 0x0000);                                                     
-        TTI_SFPLOADI(0, 0x8, 0xC2B1);                                                     
-        TTI_SFPCONFIG(0, 14, 0);       // SFPCONFIG Dest 14 = LREG[14] =            -88.5               = 0xc2b10000      
+        TTI_SFPLOADI(0, 0xA, 0x0000);
+        TTI_SFPLOADI(0, 0x8, 0xC2B1);
+        TTI_SFPCONFIG(0, 14, 0);       // SFPCONFIG Dest 14 = LREG[14] =            -88.5               = 0xc2b10000
 
-        TTI_SFPLOADI(0, 0xA, 0xaa3b);                                                     
-        TTI_SFPLOADI(0, 0x8, 0x43B8);                                                     
-        TTI_SFPCONFIG(0, 12, 0);       // SFPCONFIG Dest 12 = LREG[12] = A     =    369.329925537109375 = 0x43b8aa3b     
+        TTI_SFPLOADI(0, 0xA, 0xaa3b);
+        TTI_SFPLOADI(0, 0x8, 0x43B8);
+        TTI_SFPCONFIG(0, 12, 0);       // SFPCONFIG Dest 12 = LREG[12] = A     =    369.329925537109375 = 0x43b8aa3b
 
-        TTI_SFPLOADI(0, 0xA, 0xe9a3);                                                     
-        TTI_SFPLOADI(0, 0x8, 0x46Fd);                                                     
+        TTI_SFPLOADI(0, 0xA, 0xe9a3);
+        TTI_SFPLOADI(0, 0x8, 0x46Fd);
         TTI_SFPCONFIG(0, 13, 0);       // SFPCONFIG Dest 13 = LREG[13] = (B-C) =  32500.818359375       = 0x46fde9a3
 
 
-        // Next, set up the macro instructions which will be necessary 
-        //  - for the sanitize function: we will need a SWAP instruction 
-        //  - for the main computation function: we will need MAD, ROUND, and SHIFT instructions 
+        // Next, set up the macro instructions which will be necessary
+        //  - for the sanitize function: we will need a SWAP instruction
+        //  - for the main computation function: we will need MAD, ROUND, and SHIFT instructions
 
         // There are two ways to program the macro instruction registers, and this setup leverages both ways
         //  - we can either use the SFPCONFIG flow, by setting up the bits of the instruction into LREG[0] and then targeting the Macro instruction register
         //  - or we can use the shortcut / backdoor load method which relies on having some illegal destination register values as part of the instruction
 
-        // Use SFPCONFIG method for the SWAP instruction, since we want the SWAP itself to use a destination register which is not normally a legal value 
+        // Use SFPCONFIG method for the SWAP instruction, since we want the SWAP itself to use a destination register which is not normally a legal value
         //      (we are cheating a bit here, since we only care about one half of the swap and we want to use a constant for the other half)
-        //      
+        //
         //              imm12 = 0,       lreg_src_c = 0 (will be fed by value loaded from Dest into Loadmacro lreg_dest),  lreg_dest = LREG[14] = - 88.5,   instr_mod1 = 1 swap the values with the larger of the two ending up in lreg_dest -> but we will use the Loadmacro lreg_dest register as output
         // TTI_SFP_SWAP(0,               0,                                                                                14,                            1);
-        TTI_SFPLOADI(0, 0xA, 0x00E1);                                                     
-        TTI_SFPLOADI(0, 0x8, 0x9200);                                                     
+        TTI_SFPLOADI(0, 0xA, 0x00E1);
+        TTI_SFPLOADI(0, 0x8, 0x9200);
         TTI_SFPCONFIG(0, 0, 0);       // SFPCONFIG Dest 0 = Programmable Macro instruction 0: TTI_SFPSWAP(0, 0, 14, 1); // compare against LREG[14] (-88.5), and put the larger value into LREG[loadmacro_lreg_dest]
         TTI_SFPNOP;
 
         // Backdoor load of Macro Instruction 1
         // Dummy version of MAD instruction with lreg_dest = 4'b11_01 = 13 to install into Programmable Macro instruction register 1, which is Macro Instruction Register 5
-        TTI_SFPMAD(12, 0, 13, 13, 0);   // MACRO Instruction 1 <--- lreg X = lreg[12] (A) * lreg[0] (y) + lreg[13] (B-C)  
+        TTI_SFPMAD(12, 0, 13, 13, 0);   // MACRO Instruction 1 <--- lreg X = lreg[12] (A) * lreg[0] (y) + lreg[13] (B-C)
 
         // Backdoor load of Macro Instruction 2
         // ROUND instruction to convert FP32 result into an integer value (int16)
@@ -240,7 +240,7 @@ inline void _init_exponential_()
         TTI_SFP_STOCH_RND(0,               0,             0,              0,                  14,                                                                     14);  //Round to unsigned Int16
 
         // Backdoor load of Macro Instruction 3
-        // If using the unsigned int rounding mode, then shift by 15; SHL to move integer bits to exponent; 
+        // If using the unsigned int rounding mode, then shift by 15; SHL to move integer bits to exponent;
         TTI_SFPSHFT(15,0,15,1); // imm = 15 to shift left by 15 bits; lreg_c = 0 (will use macro reg); lreg_dest = 15 to install in Programmable Macro Instruction reg 2'b11, which is Macro Instruction Register 7
 
         // So at this point, we have the following instructions loaded into our macro registers:
@@ -257,24 +257,24 @@ inline void _init_exponential_()
         // Now we want to set up our two sequences
 
         // Sequence 1 setup: we want to Load, SWAP, <delay>, Store
-        //       Delay slot:                  0     1        2      
-        //                                                                                                                                                                                                 Use     
-        //                                                                                                                                                                                                 Loaded  Result          Macro 
-        //                                                                                                                                                                                                 Value   Value   Delay   Instruction   
-        //                                                                                                                                                                                                 SRCB    Stage   Slot    Select   
+        //       Delay slot:                  0     1        2
+        //                                                                                                                                                                                                 Use
+        //                                                                                                                                                                                                 Loaded  Result          Macro
+        //                                                                                                                                                                                                 Value   Value   Delay   Instruction
+        //                                                                                                                                                                                                 SRCB    Stage   Slot    Select
         TTI_SFPLOADI(0, 0xA, 0x0004);  // slot1 : SIMPLE UNIT, want SWAP  instruction which is in macro instruction mux[4], delayed by 0 ; not using staging flop as dest; not using load reg as srcb : 8'b0_______0_______000_____100          = 0x04
                                        // slot2 : MAD    UNIT, unused                                                                                                                                 : 8'b0_______0_______000_____000          = 0x00
         TTI_SFPLOADI(0, 0x8, 0x1300);  // slot3 : ROUND  UNIT, unused                                                                                                                                 : 8'b0_______0_______000_____000          = 0x00
                                        // slot4 : STORE  UNIT, want STORE instruction which is in macro instruction mux[3], delayed by 2 ; not using staging flop as src ;                            : 8'b0_______0_______010_____011          = 0x13
-        TTI_SFPCONFIG(0, 5, 0);        // SFPCONFIG Dest 5 = Macro Sequence Register 1 
+        TTI_SFPCONFIG(0, 5, 0);        // SFPCONFIG Dest 5 = Macro Sequence Register 1
 
 
         // Sequence 0 setup: we want to Load, MAD, <delay>, ROUND, SHIFT, Store
         //       Delay slot:                  0    1        2      3      4
-        //                                                                                                                                                                                                 Use     
-        //                                                                                                                                                                                                 Loaded  Result          Macro 
-        //                                                                                                                                                                                                 Value   Value   Delay   Instruction   
-        //                                                                                                                                                                                                 SRCB    Stage   Slot    Select   
+        //                                                                                                                                                                                                 Use
+        //                                                                                                                                                                                                 Loaded  Result          Macro
+        //                                                                                                                                                                                                 Value   Value   Delay   Instruction
+        //                                                                                                                                                                                                 SRCB    Stage   Slot    Select
         TTI_SFPLOADI(0, 0xA, 0x85DF);  // slot1 : SIMPLE UNIT, want SHIFT instruction which is in macro instruction mux[7], delayed by 3 ;     using staging flop as dest;     using load reg as srcb : 8'b1_______1_______011_____111          = 0xDF
                                        // slot2 : MAD    UNIT, want MAD   instruction which is in macro instruction mux[5], delayed by 0 ; not using staging flop as dest;     using load reg as srcb : 8'b1_______0_______000_____101          = 0x85
         TTI_SFPLOADI(0, 0x8, 0x6316);  // slot3 : ROUND  UNIT, want ROUND instruction which is in macro instruction mux[6], delayed by 2 ; not using staging flop as dest;     using                  : 8'b0_______0_______010_____110          = 0x16

--- a/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -19,13 +19,33 @@ namespace sfpu
 template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_max_int32_(const int iterations)
 {
+    // Modifies LOAD/STORE to work with INT32 2's complement, however
+    // due to a bug in Blackhole this has no effect and format is INT32 sign-magnitude.
+    constexpr auto INSTR_MOD_LOAD_STORE = InstrModLoadStore::INT32_2S_COMP;
+
+    // LOAD/STORE have the value in INT sign magnitude format and SFPU needs it as 2's complement.
+    constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+
     for (int d = 0; d < iterations; d++)
     {
-        TTI_SFPLOAD(2, 12, 3, 0);
-        TTI_SFPLOAD(0, 12, 3, 64);
+        TTI_SFPLOAD(2 /*lreg*/, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0 /*dest_reg_addr */);
+        TTI_SFPCAST(2 /*lreg*/, 3 /*ldest*/, INSTR_MOD_CAST);
+        // Required after cast due to a bug in Blackhole RTL.
+        TTI_SFPSETSGN(0 /* imm */, 3 /*lreg_c*/, 2 /*ldest*/, 0 /*imod*/);
+
+        TTI_SFPLOAD(0 /*lreg*/, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 64 /*dest_reg_addr */);
+        TTI_SFPCAST(0 /*lreg*/, 3 /*ldest*/, INSTR_MOD_CAST);
+        // Required after cast due to a bug in Blackhole RTL.
+        TTI_SFPSETSGN(0 /* imm */, 3 /*lreg_c*/, 0 /*ldest*/, 0 /*imod*/);
+
         TTI_SFPMOV(0, 0, 1, 0);
         TTI_SFPIADD(0, 2, 1, 2);
-        TTI_SFPSTORE(0, 12, 3, 0);
+
+        TTI_SFPCAST(0 /*lreg*/, 1 /*ldest*/, INSTR_MOD_CAST);
+        // Required after cast due to a bug in Blackhole RTL.
+        TTI_SFPSETSGN (0 /* imm */, 1 /*lreg_c*/, 0 /*ldest*/, 0 /*imod*/);
+        TTI_SFPSTORE(0, INSTR_MOD_LOAD_STORE, ADDR_MOD_7, 0);
+
         TTI_SFPENCC(0x003, 0, 0, 10);
         dst_reg++;
     }

--- a/common/inc/sfpu/ckernel_sfpu_max_int32.h
+++ b/common/inc/sfpu/ckernel_sfpu_max_int32.h
@@ -20,7 +20,7 @@ template <bool APPROXIMATION_MODE, int ITERATIONS>
 inline void _calculate_max_int32_(const int iterations)
 {
     // Modifies LOAD/STORE to work with INT32 2's complement, however
-    // due to a bug in Blackhole this has no effect and format is INT32 sign-magnitude.
+    // in Blackhole this has no effect and format remains INT32 sign-magnitude.
     constexpr auto INSTR_MOD_LOAD_STORE = InstrModLoadStore::INT32_2S_COMP;
 
     // LOAD/STORE have the value in INT sign magnitude format and SFPU needs it as 2's complement.

--- a/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -27,9 +27,9 @@ inline void _quant_int32_(const int iterations, const uint dst_offset)
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // operand A - fp32
-        TTI_SFPLOAD(0, 3, 3, 0);
+        TTI_SFPLOAD(0, 3, ADDR_MOD_7, 0);
         // operand B - fp32 scaler
-        TT_SFPLOAD(1, 3, 3, dst_offset * 64);
+        TT_SFPLOAD(1, 3, ADDR_MOD_7, dst_offset * 64);
         // D(A) = A*B+C, LREG[2] = zero_point
         TTI_SFPMAD(0, 1, 2, 0, 0);
         // MAD has a 2-cycle pipeline latency so we need one cycle latency until next instr can consume the result
@@ -37,7 +37,7 @@ inline void _quant_int32_(const int iterations, const uint dst_offset)
         // fp32->int8, descale value is zero (LREG_9)
         TTI_SFP_STOCH_RND(0,0,9,0,0,3);
         // LREG_0 -> dest as int32
-        TTI_SFPSTORE(0,4,3,0);
+        TTI_SFPSTORE(0,4,ADDR_MOD_7,0);
         dst_reg++;
     }
 }
@@ -53,9 +53,9 @@ inline void _requant_int32_(const int iterations, const uint dst_offset)
     for (int d = 0; d < ITERATIONS; d++)
     {
         // operand A - int32
-        TTI_SFPLOAD(0, 4, 3, 0);
+        TTI_SFPLOAD(0, 4, ADDR_MOD_7, 0);
         // operand B - fp32 scaler
-        TT_SFPLOAD(1, 3, 3, dst_offset*64);
+        TT_SFPLOAD(1, 3, ADDR_MOD_7, dst_offset*64);
         // cast int32->fp32
         TTI_SFPCAST(0, 0, 0);
         // D(A) = A*B+C, LREG[2] = zero_point
@@ -65,7 +65,7 @@ inline void _requant_int32_(const int iterations, const uint dst_offset)
         // fp32->int8, descale value is zero (LREG_9)
         TTI_SFP_STOCH_RND(0,0,9,0,0,3);
         // LREG_0 -> dest as int32
-        TTI_SFPSTORE(0,4,3,0);
+        TTI_SFPSTORE(0,4,ADDR_MOD_7,0);
         dst_reg++;
     }
 }
@@ -80,9 +80,9 @@ inline void _dequant_int32_(const int iterations, const uint dst_offset)
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // operand A - int32
-        TTI_SFPLOAD(0, 4, 3, 0);
+        TTI_SFPLOAD(0, 4, ADDR_MOD_7, 0);
         // operand B - fp32 scaler
-        TT_SFPLOAD(1, 3, 3, dst_offset*64);
+        TT_SFPLOAD(1, 3, ADDR_MOD_7, dst_offset*64);
         // cast int32->fp32
         TTI_SFPCAST(0, 0, 0);
         // D(A)) = A+(-C), LREG[10] is 1, SFPADD = LREG_A*LREG_B+LREG_C
@@ -92,7 +92,7 @@ inline void _dequant_int32_(const int iterations, const uint dst_offset)
         TTI_SFPMUL(0,1,9,0,0);
         TTI_NOP;
         // LREG_0 -> dest as fp32
-        TTI_SFPSTORE(0,3,3,0);
+        TTI_SFPSTORE(0,3,ADDR_MOD_7,0);
         dst_reg++;
     }
 }

--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -30,12 +30,12 @@ inline void bitonic_topk_load8(uint offset, uint dist) {
     uint ld_offset = (offset & 0xF) + face_offset*32;
 
     // Load 16 consecutive numbers
-    TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, ld_offset);
-    TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, ld_offset + dist);
-    
+    TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, ld_offset);
+    TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, ld_offset + dist);
+
     // Load 16 consecutive indices
-    TT_SFPLOAD(p_sfpu::LREG4, 0, ADDR_MOD_3, dst_indices_offset + ld_offset);            // How to load indices ? This is unpacked directly to dest!
-    TT_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_3, dst_indices_offset + ld_offset + dist);
+    TT_SFPLOAD(p_sfpu::LREG4, 0, ADDR_MOD_7, dst_indices_offset + ld_offset);            // How to load indices ? This is unpacked directly to dest!
+    TT_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_7, dst_indices_offset + ld_offset + dist);
 
 }
 
@@ -46,39 +46,39 @@ inline void bitonic_topk_store8(uint offset, uint dist) {
     uint ld_offset = (offset & 0xF) + face_offset*32;
 
     // Load 16 consecutive numbers
-    TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, ld_offset);
-    TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, ld_offset + dist);
-    
+    TT_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, ld_offset);
+    TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, ld_offset + dist);
+
     // Load 16 consecutive indices
-    TT_SFPSTORE(p_sfpu::LREG4, 0, ADDR_MOD_3, dst_indices_offset + ld_offset + 0);      // How to load indices ? This is unpacked directly to dest!
-    TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_3, dst_indices_offset + ld_offset + dist);
+    TT_SFPSTORE(p_sfpu::LREG4, 0, ADDR_MOD_7, dst_indices_offset + ld_offset + 0);      // How to load indices ? This is unpacked directly to dest!
+    TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, dst_indices_offset + ld_offset + dist);
 }
 
 inline void bitonic_topk_load16(uint dist0, uint dist1) {
     constexpr uint dst_indices_offset = 128;        // 2 tile x 64 rows per tile
 
     // Load 16 consecutive numbers
-    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
     if ((dist0 == 4) && (dist1 == 8)) {
-        TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, 4);
-        TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, 8);
-        TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, 12);
+        TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, 4);
+        TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, 8);
+        TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, 12);
     } else {
-        TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, 0 + dist0);
-        TT_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, dist1);
-        TT_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, dist1 + dist0);
+        TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, 0 + dist0);
+        TT_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, dist1);
+        TT_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, dist1 + dist0);
     }
-    
+
      // Load 16 consecutive indices
-    TTI_SFPLOAD(p_sfpu::LREG4, 0, ADDR_MOD_3, dst_indices_offset + 0);      // How to load indices ? This is unpacked directly to dest!
+    TTI_SFPLOAD(p_sfpu::LREG4, 0, ADDR_MOD_7, dst_indices_offset + 0);      // How to load indices ? This is unpacked directly to dest!
     if ((dist0 == 4) && (dist1 == 8)) {
-        TTI_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_3, dst_indices_offset + 4);
-        TTI_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_3, dst_indices_offset + 8);
-        TTI_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_3, dst_indices_offset + 12);
+        TTI_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_7, dst_indices_offset + 4);
+        TTI_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_7, dst_indices_offset + 8);
+        TTI_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_7, dst_indices_offset + 12);
     } else {
-        TT_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_3, dst_indices_offset + 0 + dist0);
-        TT_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_3, dst_indices_offset + dist1);
-        TT_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_3, dst_indices_offset + dist1 + dist0);
+        TT_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_7, dst_indices_offset + 0 + dist0);
+        TT_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_7, dst_indices_offset + dist1);
+        TT_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_7, dst_indices_offset + dist1 + dist0);
     }
 }
 
@@ -86,32 +86,32 @@ inline void bitonic_topk_store16(uint dist0, uint dist1) {
     constexpr uint dst_indices_offset = 128;        // 2 tile x 64 rows per tile
 
     // Load 16 consecutive numbers
-    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
     if ((dist0 == 4) && (dist1 == 8)) {
-        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 4);
-        TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_3, 8);
-        TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_3, 12);
+        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 4);
+        TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, 8);
+        TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, 12);
     } else {
-        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0 + dist0);
-        TT_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_3, dist1);
-        TT_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_3, dist1 + dist0);
+        TT_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0 + dist0);
+        TT_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, dist1);
+        TT_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, dist1 + dist0);
     }
-    
+
      // Load 16 consecutive indices
-    TTI_SFPSTORE(p_sfpu::LREG4, 0, ADDR_MOD_3, dst_indices_offset + 0);      // How to load indices ? This is unpacked directly to dest!
+    TTI_SFPSTORE(p_sfpu::LREG4, 0, ADDR_MOD_7, dst_indices_offset + 0);      // How to load indices ? This is unpacked directly to dest!
     if ((dist0 == 4) && (dist1 == 8)) {
-        TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_3, dst_indices_offset + 4);
-        TTI_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_3, dst_indices_offset + 8);
-        TTI_SFPSTORE(p_sfpu::LREG7, 0, ADDR_MOD_3, dst_indices_offset + 12);
+        TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, dst_indices_offset + 4);
+        TTI_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_7, dst_indices_offset + 8);
+        TTI_SFPSTORE(p_sfpu::LREG7, 0, ADDR_MOD_7, dst_indices_offset + 12);
     } else {
-        TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_3, dst_indices_offset + 0 + dist0);
-        TT_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_3, dst_indices_offset + dist1);
-        TT_SFPSTORE(p_sfpu::LREG7, 0, ADDR_MOD_3, dst_indices_offset + dist1 + dist0);
+        TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, dst_indices_offset + 0 + dist0);
+        TT_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_7, dst_indices_offset + dist1);
+        TT_SFPSTORE(p_sfpu::LREG7, 0, ADDR_MOD_7, dst_indices_offset + dist1 + dist0);
     }
 }
 
 inline void bitonic_topk_ph3_st4_to_1(bool dir) {
-    
+
     if (dir == (bool)SortDir::ArgMin) {
         TT_LOG("Issue max/min reverse");
         TTI_SFPCONFIG(0x104, 0xF, 1);      // Reverse the max/min behaviour of SWAP
@@ -130,7 +130,7 @@ inline void bitonic_topk_ph3_st4_to_1(bool dir) {
     TTI_SFPNOP;
 
     TTI_SFPTRANSP(0,0,0,0);
-    
+
     // Step 2
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
@@ -152,7 +152,7 @@ inline void bitonic_topk_ph3_st4_to_1(bool dir) {
 }
 
 inline void bitonic_topk_ph2_st3_to_1() {
-    
+
     // Step 3
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
@@ -176,7 +176,7 @@ inline void bitonic_topk_ph2_st3_to_1() {
 }
 
 inline void bitonic_topk_ph1_st2_to_1() {
-    
+
     TTI_SFPTRANSP(0,0,0,0);
 
     // Step 2
@@ -193,16 +193,16 @@ inline void bitonic_topk_ph1_st2_to_1() {
 }
 
 inline void bitonic_topk_ph0_st1_to_1() {
-    
+
     TTI_SFPTRANSP(0,0,0,0);
-    
+
     // Step 1
     TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
     TTI_SFPNOP;
     TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::UNCONDITIONALLY);
     TTI_SFPNOP;
-    
+
     TTI_SFPTRANSP(0,0,0,0);
 }
 
@@ -249,10 +249,10 @@ inline void _bitonic_topk_phases_steps(
     uint dst_addr_offset = 0;
     for (int face=0; face<2; face++) {
         for (int col=0; col<2; col++) {
-        
+
             bool dir = idir;
             for (int ph=i_start_phase; ph<(i_end_phase+1); ph++) {
-                
+
                 TT_LOG("Local Sort: phase = {}, dir = {}, idir = {}", ph, dir, idir);
                 TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
                 switch (ph) {
@@ -360,7 +360,7 @@ inline void _bitonic_topk_phases_steps(
         }
         dst_addr_offset = 16;
         set_dst_write_addr(dst_addr_offset);
-    }   
+    }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
@@ -411,7 +411,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
             uint rebuild_m = m_iter + 1;
             uint total_datums_to_compare = ((64 >> rebuild_m) < 2*k) ? 2*k : (64 >> rebuild_m);    // max(2*k, 64/(2^m)) total datums to compare; there's always at least 2*K datums
-            total_datums_to_compare = total_datums_to_compare >> total_datums_shift;               // Reduce by 2 if skipping last 
+            total_datums_to_compare = total_datums_to_compare >> total_datums_shift;               // Reduce by 2 if skipping last
             uint dist = (k << rebuild_m) > 32 ? 32 : (k << rebuild_m);                             // min(32, k*2^k)
             uint ld_offset = (dist >> 4)*32 + (dist & 0xF);
             uint ld_dist;
@@ -469,7 +469,7 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                         TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
                         dir = idir;
                         datums_compared = 0;
-                        uint dist = (ss == 5) ? 16 : 32; 
+                        uint dist = (ss == 5) ? 16 : 32;
                         uint inner_d = dist >> 3;           // How many loops to sort the sequence of length (2^ss / 16). Each loop sorts 16
                         uint dst_offset = 0;
                         while (datums_compared < total_datums_to_compare) {
@@ -507,12 +507,12 @@ inline void _bitonic_topk_rebuild(const bool idir, const int m_iter, const int k
                         dir = (datums_compared == sorted_seq_length) ? !dir : dir;
                     }
                 }
-                
+
             dst_addr_offset += 2;
             set_dst_write_addr(dst_addr_offset);
         }
         dst_addr_offset = 16;
-        set_dst_write_addr(dst_addr_offset);    
+        set_dst_write_addr(dst_addr_offset);
     }
 }
 

--- a/llk_lib/llk_defs.h
+++ b/llk_lib/llk_defs.h
@@ -116,4 +116,30 @@ enum struct StochRndType {
     All     = 0xf,
 };
 
+// This is populated per Blackhole ISA for SFPLOAD/SFPSTORE instructions.
+enum InstrModLoadStore
+{
+    DEFAULT = 0,
+    FP16A = 1,
+    FP16B = 2,
+    FP32 = 3,
+    INT32 = 4,
+    INT8 = 5,
+    LO16 = 6,
+    HI16 = 7,
+    INT32_2S_COMP = 12,
+    INT8_2S_COMP = 13,
+    LO16_ONLY = 14,
+    HI16_ONLY = 15
+};
+
+// This is populated per Blackhole ISA for SFPCAST instruction.
+enum InstrModCast
+{
+    INT32_TO_FP32_NEAREST_EVEN = 0,
+    INT32_TO_FP32_STOCHASTIC = 1,
+    INT32_2S_COMP_TO_INT_SIGN_MAGN = 2,
+    INT_SIGN_MAGN_TO_INT32_2S_COMP = 3
+};
+
 }  // namespace ckernel


### PR DESCRIPTION
This PR does 2 things that fix PCC errors in netlists with Int32 format that targets SFPU operations:
- Changes address mode explicitly to 7, which was always the mode used, but in WH it was set to 3 due to only 2bits available for address mode, and then additional flag was used to signal it was in fact address mode 7. In BH there are no 3 bits for address mode, so this should be explicitly set.
- LOAD/STORE for Int32 is done in sign magnitude format without the possibility to convert to 2's complement. Since SFPU expects 2's complement format, this needs to be explicitly casted. Additionally, due to an RTL bug in BH SFPSETSGN is also needed after SFPCAST.