### PR TITLE
Port fixes for tiny tile handling in input1 from WHB0

### DIFF
--- a/llk_lib/llk_math_matmul.h
+++ b/llk_lib/llk_math_matmul.h
@@ -245,29 +245,15 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
     const bool is_in0_16x32 = (in0_tile_r_dim <=FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
     const bool is_in0_32x16 = (in0_tile_r_dim > FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
-    const bool is_in0_16x16 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim <= FACE_C_DIM);
-    const bool is_in1_16x16 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    const std::uint32_t replay_buf_len = (is_in0_16x16 || is_in1_16x16 || (is_in0_16x32 && is_in1_32x16)) ? (partial_face ? 2 : 4) :
+    const std::uint32_t replay_buf_len = (is_in0_16x32 && is_in1_32x16) ? 4 :
                                          ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
 
     load_replay_buf(replay_buf_offset, replay_buf_len, false,
         // Lambda function to load reply buffer
-        [high_fidelity, reuse_a, partial_face, is_in1_16x16, is_in0_16x16, is_in1_32x16, is_in0_16x32, is_in0_32x16, is_in1_16x32, t_dim] {
-            if (is_in1_16x16) {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca=srca, srcb+=24, dest+=24 //FIXME: dest not correct
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B2A0 // // srca=srca, srcb+=8, dest+=8
-            } else if (is_in0_16x16) {
-                if (partial_face) {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest=+16, bias = 1
-                } else {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest+=8
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8
-                }
-            } else if (is_in1_32x16) {
+        [high_fidelity, reuse_a, partial_face, is_in1_32x16, is_in0_16x32, is_in0_32x16, is_in1_16x32, t_dim] {
+             if (is_in1_32x16) {
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A1 // srca=srca, srcb+=8,  dest=+8

--- a/llk_lib/llk_math_matmul.h
+++ b/llk_lib/llk_math_matmul.h
@@ -53,7 +53,7 @@ inline void matmul_configure_addrmod(const bool transpose, const std::uint32_t c
         .set(ADDR_MOD_5);
 
 
-    if (is_in0_16x32||is_in0_32x16) {
+    if ((is_in0_16x32&&(!is_in1_32x16))||is_in0_32x16) {
         if (transpose) {
             addr_mod_t{
                 .srca = {.incr = 32, .clr = 0, .cr = 0},
@@ -249,10 +249,10 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
     const bool is_in1_16x16 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
     const bool is_in1_16x32 = (in1_tile_r_dim <= FACE_R_DIM) && (in1_tile_c_dim > FACE_C_DIM);
 
-    const std::uint32_t replay_buf_len = (is_in0_16x16 || is_in1_16x16) ? (partial_face ? 2 : 4) :
+    const std::uint32_t replay_buf_len = (is_in0_16x16 || is_in1_16x16 || (is_in0_16x32 && is_in1_32x16)) ? (partial_face ? 2 : 4) :
                                          ((is_in0_16x32 || is_in1_32x16 || is_in0_32x16 || is_in1_16x32) ? (partial_face ? 4 : 8) : 16);
 
-    load_replay_buf(replay_buf_offset, replay_buf_len, false, 
+    load_replay_buf(replay_buf_offset, replay_buf_len, false,
         // Lambda function to load reply buffer
         [high_fidelity, reuse_a, partial_face, is_in1_16x16, is_in0_16x16, is_in1_32x16, is_in0_16x32, is_in0_32x16, is_in1_16x32, t_dim] {
             if (is_in1_16x16) {
@@ -266,7 +266,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest+=8
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A1 // srca=srca, srcb+=8,  dest+=8
-                }    
+                }
             } else if (is_in1_32x16) {
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16,  srcb+=8,  dest=0
@@ -279,7 +279,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
             } else if (is_in0_16x32 || is_in0_32x16) {
                 if (partial_face) {
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B0A0 // srca+=16,  srcb=0,   dest=+16
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B0A1 // srca+=16,  srcb+=16,  dest=0 (addr_mod_4), bias=0 
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_4, 0); // B0A1 // srca+=16,  srcb+=16,  dest=0 (addr_mod_4), bias=0
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0); // B1A2 // srca+=16,  srcb=0,  dest=+16
                 } else {
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
@@ -290,7 +290,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A2 // srca=srca, srcb+=8,  dest+=8
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B1A2 // srca+=16,  srcb=16,  dest+=8/24 // dest+=24 if transposed
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B1A3 // srca=srca, srcb+=8,  dest+=8
-                }    
+                }
             } else {
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B0A0 // srca=srca, srcb+=8,  dest+=8
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B0A0 // srca+=16/32, srcb=0, dest+=8  // srca+=32 if transposed
@@ -314,7 +314,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
                 }
             }
-                
+
             if constexpr(high_fidelity) {
                 // TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5)
@@ -323,7 +323,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
                     TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_5, 0); // B3A3 or B3A2 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
                 } else {
                     TTI_MVMUL(p_setrwc::CLR_B, 0, ADDR_MOD_5, 0); // B3A3 or B2A1 // reset srca/srcb/dest, increment phase (addr_mod_5), clear src A
-                }    
+                }
             }
         }
     );
@@ -337,7 +337,7 @@ inline void matmul_configure_mop(bool transpose, const std::uint32_t ct_dim, con
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
         } else {
             tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
-        }    
+        }
     }
     tmp.program(instrn_buffer);
 }
@@ -346,7 +346,7 @@ template <int MATH_FIDELITY_DESC, DstTileFaceLayout FaceLayout=DstTileFaceLayout
 inline void _llk_math_matmul_init_(const std::uint32_t in0_tile_r_dim = TILE_R_DIM, const std::uint32_t in0_tile_c_dim = TILE_C_DIM, const std::uint32_t in1_tile_r_dim = TILE_R_DIM, const std::uint32_t in1_tile_c_dim = TILE_C_DIM, const bool partial_face = false, const std::uint32_t transpose=0, const std::uint32_t ct_dim=1, const std::uint32_t rt_dim=1, const std::uint32_t kt_dim=1) {
 
     matmul_configure_addrmod<MATH_FIDELITY_DESC, FaceLayout>(transpose, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
-    
+
     constexpr int MATH_FIDELITY_PHASES = get_math_num_fidelity_phases(MATH_FIDELITY_DESC);
     matmul_configure_mop<MATH_FIDELITY_PHASES, FaceLayout>(transpose>0, ct_dim, rt_dim, kt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
     math::reset_counters(p_setrwc::SET_ABD_F);

--- a/llk_lib/llk_unpack_AB_matmul.h
+++ b/llk_lib/llk_unpack_AB_matmul.h
@@ -22,7 +22,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
     const bool reuse_a = ct_dim >= rt_dim;
     const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 16 : ((!reuse_a && unpB_partial_face) ? 16 : 10);
     const std::uint32_t replay_buf_run_len  = replay_buf_prog_len/2;
-    TT_LOG("reuseA: {}, unpA_partial_face: {}, replay_buf_prog_len: {}", reuse_a, unpA_partial_face, replay_buf_prog_len);
+
     if (reuse_a) {
         #if SKIP_UNP == 1
             load_replay_buf<0, 1>([] {
@@ -52,6 +52,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC0_REG3_Base_address_ADDR32);
                     }
+                    // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
+                    TTI_NOP;
 
                     if (unpA_partial_face) {
                         TTI_UNPACR_NOP(SrcA, 0, 0, 0/*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
@@ -72,6 +74,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
                     }
+                    // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
+                    TTI_NOP;
                 }
             );
         #endif
@@ -104,6 +108,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC1_REG3_Base_address_ADDR32);
                     }
+                    // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
+                    TTI_NOP;
 
                     if (unpB_partial_face) {
                         TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
@@ -124,6 +130,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
                     }
+                    // Added to ensure WRCFG instruction has finished, since it takes 2 cycles.
+                    TTI_NOP;
                 }
             );
         #endif

--- a/llk_lib/llk_unpack_AB_matmul.h
+++ b/llk_lib/llk_unpack_AB_matmul.h
@@ -20,9 +20,9 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
     // in1/inB - loaded to SrcA
 
     const bool reuse_a = ct_dim >= rt_dim;
-    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 16 : ((!reuse_a && unpB_partial_face) ? 16 : 12);
+    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 16 : ((!reuse_a && unpB_partial_face) ? 16 : 10);
     const std::uint32_t replay_buf_run_len  = replay_buf_prog_len/2;
-
+    TT_LOG("reuseA: {}, unpA_partial_face: {}, replay_buf_prog_len: {}", reuse_a, unpA_partial_face, replay_buf_prog_len);
     if (reuse_a) {
         #if SKIP_UNP == 1
             load_replay_buf<0, 1>([] {
@@ -34,7 +34,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                 // Lambda function to set up replay buffer
                 [unpA_partial_face] {
                     if (unpA_partial_face) {
-                        TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                        TTI_UNPACR_NOP(SrcA, 0, 0, 0/*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
                         TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
@@ -42,6 +42,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_UNPACR(SrcA, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                     }
                     if constexpr (kernel_broadcast_b==1) {
+                        TTI_NOP;
                         TTI_NOP;
                         TTI_NOP;
                         TTI_NOP;
@@ -51,9 +52,9 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC0_REG3_Base_address_ADDR32);
                     }
-                    TTI_NOP;
+
                     if (unpA_partial_face) {
-                        TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                        TTI_UNPACR_NOP(SrcA, 0, 0, 0/*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
                         TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
@@ -64,13 +65,13 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_NOP;
                         TTI_NOP;
                         TTI_NOP;
+                        TTI_NOP;
                     } else {
                         TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
                         TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TILE_SIZE_A);
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
                     }
-                    TTI_NOP;
                 }
             );
         #endif
@@ -85,6 +86,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                 // Lambda function to set up replay buffer
                 [unpB_partial_face] {
                     if (unpB_partial_face) {
+                        TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
                         TTI_UNPACR(SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_UNPACR(SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
@@ -92,6 +94,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_UNPACR(SrcB, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                     }
                     if constexpr (kernel_broadcast_a==1) {
+                        TTI_NOP;
                         TTI_NOP;
                         TTI_NOP;
                         TTI_NOP;
@@ -101,8 +104,9 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC1_REG3_Base_address_ADDR32);
                     }
-                    TTI_NOP;
+
                     if (unpB_partial_face) {
+                        TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
                         TTI_UNPACR(SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_UNPACR(SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                         TTI_SETADCZW(p_setadc::UNP_B, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0
@@ -113,13 +117,13 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
                         TTI_NOP;
                         TTI_NOP;
                         TTI_NOP;
+                        TTI_NOP;
                     } else {
                         TTI_RDCFG(p_gpr_unpack::TMP0, THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
                         TTI_ADDDMAREG(0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP0, p_gpr_unpack::TMP_LO);
                         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
                         TTI_WRCFG(p_gpr_unpack::TMP0,0,THCON_SEC1_REG3_Base_cntx1_address_ADDR32);
                     }
-                    TTI_NOP;
                 }
             );
         #endif
@@ -259,6 +263,7 @@ inline void _llk_unpack_AB_matmul_(
                 TTI_NOP;
             #else
                 if (unpB_partial_face) {
+                    TTI_UNPACR_NOP(SrcB, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
                     // Do face by face unpacking
                     TTI_UNPACR(SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                     TTI_UNPACR(SrcB, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
@@ -273,7 +278,7 @@ inline void _llk_unpack_AB_matmul_(
             #else
                 if (unpA_partial_face) {
                     // Do face by face unpacking
-                    TTI_UNPACR_NOP(SrcA, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+                    TTI_UNPACR_NOP(SrcA, 0, 0, 0 /*Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
                     TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 0 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                     TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /* Set ContextIdInc */, 0, 0, 1);
                     TTI_SETADCZW(p_setadc::UNP_A, 0, 0, 0, 0, 0b0101); // Set ch0_z=0, ch1_z=0

--- a/llk_lib/llk_unpack_AB_matmul.h
+++ b/llk_lib/llk_unpack_AB_matmul.h
@@ -20,7 +20,7 @@ inline void _llk_unpack_AB_matmul_mop_config_(const bool transpose, const std::u
     // in1/inB - loaded to SrcA
 
     const bool reuse_a = ct_dim >= rt_dim;
-    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 16 : ((!reuse_a && unpB_partial_face) ? 16 : 10);
+    const std::uint32_t replay_buf_prog_len = (reuse_a && unpA_partial_face) ? 18 : ((!reuse_a && unpB_partial_face) ? 18 : 12);
     const std::uint32_t replay_buf_run_len  = replay_buf_prog_len/2;
 
     if (reuse_a) {


### PR DESCRIPTION
This PR has fixes for tiny tile handling on LLK side for input1, which are ported from WH B0.
Additionally, code is cleaned up a bit and adjusted for BH:
- The change consists of using UNPACR_NOP instruction differently, since it changed in BH.
- And aligning number of instructions in Replay buffer for all code paths.