### PR TITLE
Rd/uint8 a2d

### DIFF
--- a/common/inc/cpack_common.h
+++ b/common/inc/cpack_common.h
@@ -300,7 +300,7 @@ namespace ckernel::packer
          dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_unsigned = 1;
       }
       //Round to 10 bit mantissa from fp32 dest
-      if(is_fp32_dest_acc_en && (pack_src_format!=(uint)DataFormat::Float32)) {
+      if(is_fp32_dest_acc_en && (pack_output_src_format == (uint)DataFormat::Float16)) {
          dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Round_10b_mant = 1;
       }
       cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_ADDR32,


### PR DESCRIPTION
Fix the PCK_DEST_RD_CTRL_Round_10b_mant in the packer reconfig to depend on the same data format as in the config. (FP32 -> FP16A)