### PR TITLE
Shorten the fw code for trisc0

### DIFF
--- a/common/inc/cpack_common.h
+++ b/common/inc/cpack_common.h
@@ -291,8 +291,7 @@ namespace ckernel::packer
 
       dest_rd_ctrl_u dest_rd_ctrl;
       dest_rd_ctrl.val = 0;
-      dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_src_format == (uint)DataFormat::Int8) | 
-                                                      (pack_src_format == (uint)DataFormat::UInt8) |
+      dest_rd_ctrl.f.PCK_DEST_RD_CTRL_Read_32b_data = (pack_output_src_format == (uint)DataFormat::Int8) |
                                                       (pack_src_format == (uint)DataFormat::Int32) |
                                                       (pack_src_format == (uint)DataFormat::Float32) |
                                                       (is_fp32_dest_acc_en ? 1 : 0);

--- a/llk_lib/llk_unpack_common.h
+++ b/llk_lib/llk_unpack_common.h
@@ -87,10 +87,9 @@ inline void _llk_unpack_reconfig_data_format_srca_impl_(const std::uint32_t unpa
     if ((uint)unpack_src_format == (uint)DataFormat::UInt8) {
         alu_payload.f.ALU_FORMAT_SPEC_REG0_SrcAUnsigned = 1;
     }
-    alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = ((uint)unpack_dst_format == (uint)DataFormat::Int8) ||
-                                                   ((uint)unpack_dst_format == (uint)DataFormat::UInt8) ||
+    alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = ((uint)(unpack_dst_format & 0xF) == (uint)DataFormat::Int8) ||
                                                    ((uint)unpack_dst_format == (uint)DataFormat::Int32);
-    constexpr uint alu_mask =  ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
+    constexpr uint alu_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, alu_mask>(alu_payload.val);
     
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0x0f>(unpack_src_format);


### PR DESCRIPTION
Shorten TRISC0_FIRMWARE_CODE to help with overflow issues.
Here, I just combined Int8 and UInt8 comparisons into 1 using bitwise and.