### PR TITLE
#13548: Remove default argument for DstSync

### DIFF
--- a/llk_lib/llk_math_common.h
+++ b/llk_lib/llk_math_common.h
@@ -47,7 +47,7 @@ inline void _llk_math_wait_for_dest_available_() {
 #endif
 }
 
-template <DstSync Dst = SyncFull, bool is_fp32_dest_acc_en = false>
+template <DstSync Dst, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_dest_section_done_() {
 #ifdef PERF_DUMP
     if constexpr(MATH_PACK_DECOUPLE) {

--- a/llk_lib/llk_math_eltwise_binary.h
+++ b/llk_lib/llk_math_eltwise_binary.h
@@ -27,7 +27,7 @@ inline void eltwise_binary_reuse_dest_as_src() {
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
-    DstSync Dst = DstSync::SyncFull,
+    DstSync Dst,
     int NUM_FIDELITY_PHASES = 0,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool is_fp32_dest_acc_en = false>

--- a/llk_lib/llk_math_eltwise_binary_sfpu.h
+++ b/llk_lib/llk_math_eltwise_binary_sfpu.h
@@ -30,7 +30,7 @@ inline void eltwise_binary_sfpu_configure_addrmod(){
 }
 inline void eltwise_binary_sfpu_configure_mop();
 
-template <DstSync Dst = DstSync::SyncFull>
+template <DstSync Dst>
 inline void _llk_math_eltwise_binary_sfpu_start_(const uint dst_index) {
     if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2)) {
         math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);

--- a/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -17,7 +17,7 @@ using namespace ckernel;
 // local function declarations
 inline void eltwise_unary_configure_addrmod();
 
-template <DataCopyType type, BroadcastType src_b_bcast_type = BroadcastType::NONE, DstSync Dst = DstSync::SyncFull, bool is_fp32_dest_acc_en = false, bool unpack_to_dest = false>
+template <DataCopyType type, DstSync Dst, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool is_fp32_dest_acc_en = false, bool unpack_to_dest = false>
 inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, const std::uint32_t src_format, const std::uint32_t dst_format) {
 
         std::uint32_t constexpr num_faces = 4;

--- a/llk_lib/llk_math_eltwise_unary_sfpi.h
+++ b/llk_lib/llk_math_eltwise_unary_sfpi.h
@@ -30,7 +30,7 @@ inline void eltwise_unary_sfpi_configure_addrmod(){
 }
 inline void eltwise_unary_sfpi_configure_mop();
 
-template <SfpiTestType sfpu_op, DstSync Dst = DstSync::SyncFull>
+template <SfpiTestType sfpu_op, DstSync Dst>
 inline void llk_math_eltwise_unary_sfpi(
     uint dst_index,
     uint param0 = 0,
@@ -63,97 +63,97 @@ inline void llk_math_eltwise_unary_sfpi_init(
 
 // New LLK SFPU APIs
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test1(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test1, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test2(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test2, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test3(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test3, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test4(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test4, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test5(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test5, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test6(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test6, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test7(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test7, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test8(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test8, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test9(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test9, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test10(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test10, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test11(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test11, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test12(uint dst_index, uint param0) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test12, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test13(uint dst_index, uint param0) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test13, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test14(uint dst_index, uint param0) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test14, dst_sync>(dst_index, param0);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test15(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test15, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test16(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test16, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test17(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test17, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test18(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test18, dst_sync>(dst_index);
 }
 
-template <DstSync dst_sync = DstSync::SyncFull>
+template <DstSync dst_sync>
 inline void llk_math_eltwise_unary_sfpi_test19(uint dst_index) {
     llk_math_eltwise_unary_sfpi<SfpiTestType::test19, dst_sync>(dst_index);
 }

--- a/llk_lib/llk_math_eltwise_unary_sfpu.h
+++ b/llk_lib/llk_math_eltwise_unary_sfpu.h
@@ -38,7 +38,7 @@ inline void eltwise_unary_sfpu_configure_addrmod(){
 }
 inline void eltwise_unary_sfpu_configure_mop();
 
-template <DstSync Dst = DstSync::SyncFull>
+template <DstSync Dst>
 inline void _llk_math_eltwise_unary_sfpu_start_(const uint dst_index) {
     if constexpr ((Dst == DstSync::SyncTile16) || (Dst == DstSync::SyncTile2)) {
         math::set_dst_write_addr<DstTileLayout::Default, DstTileShape::Tile32x32>(math_sync_tile_dst_index);

--- a/llk_lib/llk_pack.h
+++ b/llk_lib/llk_pack.h
@@ -306,7 +306,7 @@ inline void _llk_pack_init_(const std::uint32_t pack_dst_format, const std::uint
     );
 }
 
-template <DstSync Dst = SyncFull, bool untilize = false, bool is_fp32_dest_acc_en = false>
+template <DstSync Dst, bool untilize = false, bool is_fp32_dest_acc_en = false>
 inline void _llk_pack_(const std::uint32_t tile_index, const std::uint32_t address) {
 
     if constexpr (Dst == DstSync::SyncTile16) {


### PR DESCRIPTION
Remove the default argument value for DstSync as this is determined using compute kernel config and we do not want it to conflict with the config if user does not provide the value specifically and relies on the default value. 

Corresponding PR for tt-metal : https://github.com/tenstorrent/tt-metal/pull/13661