### PR TITLE
Use even rounding in sin/cos

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_trigonometry.h
+++ b/common/inc/sfpu/ckernel_sfpu_trigonometry.h
@@ -83,7 +83,7 @@ inline void _calculate_sine_(const int iterations)
     {
         vFloat v = dst_reg[0];
         v = 0.318309886183791f*v; // *1/pi to get number of pi rads.
-        vInt whole_v = float_to_int16(v);
+        vInt whole_v = float_to_int16(v, 0);
         vFloat whole_v_float = int32_to_float(whole_v, 0);
         v = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]
@@ -107,7 +107,7 @@ inline void _calculate_cosine_(const int iterations)
     {
         vFloat v = dst_reg[0];
         v = 0.318309886183791f*v; // *1/pi to get number of pi rads.
-        vInt whole_v = float_to_int16(v);
+        vInt whole_v = float_to_int16(v, 0);
         vFloat whole_v_float = int32_to_float(whole_v, 0);
         v = v - whole_v_float;
         v *= 3.141592653589793f; // fractional * pi to get it in [-pi:pi]


### PR DESCRIPTION
Switch `float_to_int16` in sin/cos to use even rounding instead of stochastic.