### PR TITLE
#12855: Fix unpacker race condition by putting stall after MMIO

### DIFF
--- a/llk_lib/llk_unpack_AB_matmul.h
+++ b/llk_lib/llk_unpack_AB_matmul.h
@@ -255,8 +255,6 @@ inline void _llk_unpack_AB_matmul_(
         // Wait for free context
         wait_for_next_context(2);
 
-        semaphore_post(semaphore::UNPACK_SYNC);  // Trisc::SEMPOST for context acquire
-
         // Program unpacker 1 base address
         if (0 == unp_cfg_context) {
             cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address_b;
@@ -265,6 +263,11 @@ inline void _llk_unpack_AB_matmul_(
             cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address_b;
             cfg[THCON_SEC1_REG3_Base_cntx1_address_ADDR32] = address_a;
         }
+
+        semaphore_post(semaphore::UNPACK_SYNC);  // Trisc::SEMPOST for context acquire
+
+        // Stall unpacker until pending CFG writes from Trisc have completed
+        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
 
         if (reuse_a) {
             #if SKIP_UNP == 1


### PR DESCRIPTION
Fix the race condition by introducing a stall. Brought down the semaphore_post right before the stall as this is supposed to have no functional change. Since you cannot write to the address which is currently being used by the unpacker since there is a wait_for_next_context(2) right above it. Context can start from 0, then go to 1 and then come back to 0 and reach the MMIO writes when wait_for_next_context(2) passes, and that happens when the code that was previously working in context 0 has finished. Same argument for context 1. 