### PR TITLE
#14609: Workaround PACK/MATH sync before CFG change

### DIFF
--- a/llk_lib/llk_math_common.h
+++ b/llk_lib/llk_math_common.h
@@ -16,6 +16,12 @@ using namespace ckernel::math;
 
 template <bool untilize_en = false, bool skip_inputs = false>
 inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format) {
+    // tt-metal #14609 workaround - wait until PACK and MATH are idle so
+    // that remap_addrs and swizzle_32b bits can be changed
+    tensix_sync();
+    while (semaphore_read(semaphore::MATH_PACK) > 0) {
+    };  // Wait for previous packs to finish before claiming all dest
+
     //Untilize mode needs dest read access with a stride of 16
     //Following bits are needed for enabling stride of 16
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_remap_addrs_RMW>(untilize_en);


### PR DESCRIPTION
Ticket
tt-metal#14609  

Problem description
Due to a HW bug, the ```DEST_ACCESS_CFG_remap_addrs_RMW``` and ```DEST_ACCESS_CFG_swizzle_32b_RMW``` bits cannot be changed until MATH and PACK thread are idle.

What's changed:
Introduce a synchronization point on MATH thread that makes the HW wait for MATH to be idle before continuing to modify the DEST_ACCESS_CFG bits. 
