### PR TITLE
#0: Update comment for strided mode sync

### DIFF
--- a/llk_lib/llk_math_common.h
+++ b/llk_lib/llk_math_common.h
@@ -16,8 +16,8 @@ using namespace ckernel::math;
 
 template <bool untilize_en = false, bool skip_inputs = false>
 inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format) {
-    // tt-metal #14609 workaround - wait until PACK and MATH are idle so
-    // that remap_addrs and swizzle_32b bits can be changed
+    // Need to wait for all DEST accesses to be finished before changing 
+    // remap_addrs and swizzle_32b bits
     tensix_sync();
     while (semaphore_read(semaphore::MATH_PACK) > 0) {
     };  // Wait for previous packs to finish before claiming all dest


### PR DESCRIPTION
In order to do pack_untilize we need to set the DEST access mode to strided. The following bits need to be set to enable correct stride amount and proper 32-bit data format handling - ```DEST_ACCESS_CFG_remap_addrs_RMW``` and ```DEST_ACCESS_CFG_swizzle_32b_RMW```. Since this is the part of the global CFG, we need to wait for all DEST accesses to finish before changing these bits (as nicely explained here: https://yyz-gitlab.local.tenstorrent.com/tenstorrent/budabackend/-/issues/1849). 

The sync introduced in ```_llk_math_hw_configure_```, in ```tt_metal/third_party/tt_llk_blackhole/llk_lib/llk_math_common.h``` allows for our LLK implementation to be in line with the HW design and specification. 

The fix was introduced to tt-metal as a part of [PR#15398](https://github.com/tenstorrent/tt-metal/pull/15398) as the mismatch was identified in the issue [#14609](https://github.com/tenstorrent/tt-metal/issues/14609)