### PR TITLE
Fix PACKER tilize and untilize erroneous tile closing

### DIFF
--- a/llk_lib/llk_math_common.h
+++ b/llk_lib/llk_math_common.h
@@ -18,10 +18,14 @@ template <bool untilize_en = false, bool skip_inputs = false>
 inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format) {
     //Untilize mode needs dest read access with a stride of 16
     //Following bits are needed for enabling stride of 16
+
+    tensix_sync();
+    while (semaphore_read(semaphore::MATH_PACK) > 0) {};
+
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_remap_addrs_RMW>(untilize_en);
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_swizzle_32b_RMW>(untilize_en);
-    
-    // Legacy mode for ZEROACC 
+
+    // Legacy mode for ZEROACC
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_zeroacc_absolute_tile_mode_RMW>(1);
 
     if constexpr (skip_inputs == false){
@@ -168,7 +172,7 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
 }
 
 inline std::uint32_t _llk_math_get_compute_special_value_flags_() {
-    return reg_read(RISCV_DEBUG_REG_FPU_STICKY_BITS); 
+    return reg_read(RISCV_DEBUG_REG_FPU_STICKY_BITS);
 }
 
 inline void _llk_math_clear_compute_special_value_flags_() {

--- a/llk_lib/llk_math_common.h
+++ b/llk_lib/llk_math_common.h
@@ -16,18 +16,13 @@ using namespace ckernel::math;
 
 template <bool untilize_en = false, bool skip_inputs = false>
 inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const std::uint32_t srcb_data_format) {
-    // Need to wait for all DEST accesses to be finished before changing 
+    // Need to wait for all DEST accesses to be finished before changing
     // remap_addrs and swizzle_32b bits
     tensix_sync();
-    while (semaphore_read(semaphore::MATH_PACK) > 0) {
-    };  // Wait for previous packs to finish before claiming all dest
+    while (semaphore_read(semaphore::MATH_PACK) > 0) {};  // Wait for previous packs to finish before claiming all dest
 
     //Untilize mode needs dest read access with a stride of 16
     //Following bits are needed for enabling stride of 16
-
-    tensix_sync();
-    while (semaphore_read(semaphore::MATH_PACK) > 0) {};
-
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_remap_addrs_RMW>(untilize_en);
     cfg_reg_rmw_tensix<DEST_ACCESS_CFG_swizzle_32b_RMW>(untilize_en);
 

--- a/llk_lib/llk_pack.h
+++ b/llk_lib/llk_pack.h
@@ -159,10 +159,6 @@ inline void _llk_pack_mop_config_(const std::uint32_t pack_dst_format, const std
             }
         );
 
-        // ckernel::ckernel_template tmp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_0, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0));
-        // tmp.set_last_inner_loop_instr(TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_1, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_0, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0));
-        // tmp.set_last_outer_loop_instr(TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0));
-
         ckernel::ckernel_template tmp(
             MOP_OUTER_LOOP,
             MOP_INNER_LOOP,

--- a/llk_lib/llk_pack.h
+++ b/llk_lib/llk_pack.h
@@ -128,7 +128,9 @@ inline void _llk_pack_mop_config_(const std::uint32_t pack_dst_format, const std
         const uint PACK_INTF_SEL_1 = 0b1010;
         const uint MOP_INNER_LOOP = 1;
         const uint MOP_OUTER_LOOP = 2;
-        const uint replay_buf_len = 16;
+
+        // Last row of half-tile (16 rows) is different between halves, so can't be replayed.
+        const uint replay_buf_len = 15;
 
         //This replay buffer finishes 2 faces
         load_replay_buf(0, replay_buf_len, false,
@@ -152,7 +154,7 @@ inline void _llk_pack_mop_config_(const std::uint32_t pack_dst_format, const std
                 TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0);
                 TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0);
                 TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0);
-                TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1);
+                // Last PACR instruction of the half-tile must go separately in the MOP. This is to be able to override it, to ensure that for the second half the tile is closed correctly.
 
             }
         );
@@ -164,8 +166,12 @@ inline void _llk_pack_mop_config_(const std::uint32_t pack_dst_format, const std
         ckernel::ckernel_template tmp(
             MOP_OUTER_LOOP,
             MOP_INNER_LOOP,
-            TT_OP_REPLAY(0, replay_buf_len, 0, 0)
+            TT_OP_REPLAY(0, replay_buf_len, 0, 0),
+            TT_OP_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 0) // don't close tile
         );
+
+        // Close the tile only when it is actually done.
+        tmp.set_last_outer_loop_instr(TT_OP_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_NORMAL_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL_1, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1));
 
         if constexpr (write_tile_header) {
             tmp.set_end_ops(

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -14,7 +14,6 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
-#include "debug/dprint.h"
 template <bool diagonal = false>
 inline void _llk_pack_untilize_configure_addrmod_() {
     static_assert(!diagonal, "Diagonal not supported");

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -14,12 +14,13 @@
 using namespace ckernel;
 using namespace ckernel::packer;
 
+#include "debug/dprint.h"
 template <bool diagonal = false>
 inline void _llk_pack_untilize_configure_addrmod_() {
     static_assert(!diagonal, "Diagonal not supported");
 
     addr_mod_pack_t{
-        .y_src = {.incr = 0, .clr = 0}, 
+        .y_src = {.incr = 0, .clr = 0},
     }
     .set(ADDR_MOD_0);
 
@@ -27,10 +28,9 @@ inline void _llk_pack_untilize_configure_addrmod_() {
     //     .y_src = { .incr = 1, .clr = 0},
     // }.set(ADDR_MOD_1);
 
-    // addr_mod_pack_t{
-    //     .y_src = { .incr = 0, .clr = 1 },
-    //     .z_src = { .incr = 1, .clr = 0 },
-    // }.set(ADDR_MOD_2);
+    addr_mod_pack_t{
+        .z_src = { .clr = 1 },
+    }.set(ADDR_MOD_2);
 
 }
 
@@ -46,16 +46,16 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
     /*
     Each pack instruction does 2x16 datums if (num_faces>1)
     Each row of 16 datums, has a stride of 16 from dest read
-    Dest row read in inner loop: 
-    tile 0: row 0, row 16 
+    Dest row read in inner loop:
+    tile 0: row 0, row 16
     tile 1: row 64, row 80
     .
     tile block_ct_dim-1: row 64*(block_ct_dim-1), row 64*(block_ct_dim-1)+16
     */
 
     ckernel::ckernel_template tmp(
-        MOP_OUTER_LOOP, 
-        MOP_INNER_LOOP, 
+        MOP_OUTER_LOOP,
+        MOP_INNER_LOOP,
         TT_OP_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, 0, PACK_INTF_SEL, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0),
         TT_OP_INCADCZW(p_setadc::PAC, 0, 0, 1, 0) // w cnt points to the next tile
     );
@@ -90,9 +90,9 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
 
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_init_(
-    const std::uint32_t pack_src_format, 
-    const std::uint32_t pack_dst_format, 
-    const std::uint32_t face_r_dim = FACE_R_DIM, 
+    const std::uint32_t pack_src_format,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim = FACE_R_DIM,
     const std::uint32_t num_faces = 4) {
     static_assert(!diagonal, "Diagonal not supported");
     _llk_pack_untilize_configure_addrmod_<diagonal>();
@@ -114,10 +114,10 @@ inline void _llk_pack_untilize_init_(
 
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim, bool diagonal = false>
 inline void _llk_pack_untilize_(
-    const std::uint32_t address, 
+    const std::uint32_t address,
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM, 
-    const std::uint32_t num_faces = 4, 
+    const std::uint32_t face_r_dim = FACE_R_DIM,
+    const std::uint32_t num_faces = 4,
     const std::uint32_t tile_dst_offset = 0) {
 
     // program_packer_untilized_destination<block_ct_dim, full_ct_dim, diagonal>(address, pack_dst_format);
@@ -127,9 +127,35 @@ inline void _llk_pack_untilize_(
     TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0011); //reset ch0 zw counters
     TT_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0011); //reset ch0 xy counters
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_dst_offset);
-    
+
     for (std::uint32_t face=0; face<num_faces_per_rdim_tile; face++) {
-        ckernel::ckernel_template::run(instrn_buffer);
+        //ckernel::ckernel_template::run(instrn_buffer);
+
+        constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
+        constexpr uint MEGAROW = 1;
+        const uint PACK_INTF_SEL = p_pacr::TWO_INTFS_ACTIVE;
+        int in = 0;
+        int out = 0;
+        for (std::uint32_t outer_loop = 0; outer_loop < face_r_dim; outer_loop++)
+        {
+            TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010);
+            for (std::uint32_t inner_loop = 0; inner_loop < block_ct_dim; inner_loop++)
+            {
+                if (face == 1 && outer_loop == face_r_dim - 1 && inner_loop == block_ct_dim - 1)
+                {
+                   // DPRINT << "Close tile: " << inner_loop << ", " << outer_loop << ", " << face << ENDL();
+                    TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1); // close block
+                }
+                else
+                {
+                    //DPRINT << "Megarow: " << inner_loop << ", " << outer_loop << ", " << face << ", " << block_ct_dim << ENDL();
+                    TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, 0, PACK_INTF_SEL, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0);
+                }
+                TT_INCADCZW(p_setadc::PAC, 0, 0, 1, 0); // w cnt points to the next tile
+            }
+            TT_INCADCXY(p_setadc::PAC, 0, 0, 1, 0);
+        }
+
         TTI_INCADCZW(p_setadc::PAC, 0, 0, 0, 1); // z cnt increments by 2xface_r_dimxFACE_C_DIM
         TTI_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0010); //reset ch0_y counters
     }
@@ -137,6 +163,8 @@ inline void _llk_pack_untilize_(
     if constexpr (block_ct_dim == full_ct_dim) {
         constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
         const uint PACK_INTF_SEL = p_pacr::TWO_INTFS_ACTIVE;
-        TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1); // close block
+        //TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1); // close block
     }
+
+    TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0101); //reset z counters
 }

--- a/llk_lib/llk_pack_untilize.h
+++ b/llk_lib/llk_pack_untilize.h
@@ -40,7 +40,11 @@ inline void _llk_pack_untilize_mop_config_(const std::uint32_t face_r_dim = FACE
     constexpr uint MEGAROW = 1;
     constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
     constexpr uint MOP_INNER_LOOP = block_ct_dim;
-    const uint MOP_OUTER_LOOP = face_r_dim;
+
+    // Loop until face_r_dim - 1.
+    // Last row of face needs to be handled differently depending on num_faces, block_ct and full_ct.
+    const uint MOP_OUTER_LOOP = face_r_dim - 1;
+
     const uint PACK_INTF_SEL = (num_faces>1) ? p_pacr::TWO_INTFS_ACTIVE: p_pacr::SINGLE_INTF_ACTIVE;
 
     /*
@@ -123,47 +127,50 @@ inline void _llk_pack_untilize_(
     // program_packer_untilized_destination<block_ct_dim, full_ct_dim, diagonal>(address, pack_dst_format);
     program_packer_destination(address);
     const std::uint32_t num_faces_per_rdim_tile = (num_faces>2) ? 2 : 1;
+    const uint PACK_INTF_SEL = (num_faces>1) ? p_pacr::TWO_INTFS_ACTIVE: p_pacr::SINGLE_INTF_ACTIVE;
 
     TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0011); //reset ch0 zw counters
     TT_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0011); //reset ch0 xy counters
     TT_SETADC(p_setadc::PAC, p_setadc::CH_0, p_setadc::SET_W, tile_dst_offset);
 
     for (std::uint32_t face=0; face<num_faces_per_rdim_tile; face++) {
-        //ckernel::ckernel_template::run(instrn_buffer);
+        ckernel::ckernel_template::run(instrn_buffer);
 
-        constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
-        constexpr uint MEGAROW = 1;
-        const uint PACK_INTF_SEL = p_pacr::TWO_INTFS_ACTIVE;
-        int in = 0;
-        int out = 0;
-        for (std::uint32_t outer_loop = 0; outer_loop < face_r_dim; outer_loop++)
+        //-----------------------------------------------------------------------
+        // Handle last row of face, i.e. last outer_loop iteration of MOP.
+        // Start OP is the same for all cases.
+        TTI_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010); // reset ch0 W counter
+
+        // Inner loop of MOP.
+        for (std::uint32_t i = 0; i < block_ct_dim; i++)
         {
-            TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0010);
-            for (std::uint32_t inner_loop = 0; inner_loop < block_ct_dim; inner_loop++)
+            // Close block if it is the last PACR instruction of the block.
+            if ((face == num_faces_per_rdim_tile - 1) && (i == block_ct_dim - 1) && (block_ct_dim == full_ct_dim))
             {
-                if (face == 1 && outer_loop == face_r_dim - 1 && inner_loop == block_ct_dim - 1)
-                {
-                   // DPRINT << "Close tile: " << inner_loop << ", " << outer_loop << ", " << face << ENDL();
-                    TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1); // close block
-                }
-                else
-                {
-                    //DPRINT << "Megarow: " << inner_loop << ", " << outer_loop << ", " << face << ", " << block_ct_dim << ENDL();
-                    TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, 0, PACK_INTF_SEL, 0, MEGAROW, p_pacr::NO_CTXT_CTRL, 0, 0);
-                }
-                TT_INCADCZW(p_setadc::PAC, 0, 0, 1, 0); // w cnt points to the next tile
+                TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_INTF_SEL, 0, 0/*MEGAROW*/, p_pacr::NO_CTXT_CTRL, 0, 1);
             }
-            TT_INCADCXY(p_setadc::PAC, 0, 0, 1, 0);
+            else
+            {
+                TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_0, p_pacr::ADDR_CNT_CTXT_0, p_pacr::P_ZERO_OUTPUT_DISABLED, PACK_INTF_SEL, 0, 1/*MEGAROW*/, p_pacr::NO_CTXT_CTRL, 0, 0);
+            }
+
+            TTI_INCADCZW(p_setadc::PAC, 0, 0, 1, 0); // w cnt points to the next tile
         }
+
+        // End OP.
+        TTI_INCADCXY(p_setadc::PAC, 0, 0, 1, 0); //inc ch0_y counters
+        if (block_ct_dim != full_ct_dim)
+        {
+            // update l1 address
+            TTI_ADDDMAREG(0, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR, p_gpr_pack::OUTPUT_ADDR_OFFSET);
+            TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
+            TTI_WRCFG(p_gpr_pack::OUTPUT_ADDR, 0, THCON_SEC0_REG1_L1_Dest_addr_ADDR32);
+            TTI_NOP;
+        }
+        //-----------------------------------------------------------------------
 
         TTI_INCADCZW(p_setadc::PAC, 0, 0, 0, 1); // z cnt increments by 2xface_r_dimxFACE_C_DIM
         TTI_SETADCXY(p_setadc::PAC, 0, 0, 0, 0, 0b0010); //reset ch0_y counters
-    }
-
-    if constexpr (block_ct_dim == full_ct_dim) {
-        constexpr uint ZERO_OUTPUT_FLAG = p_pacr::P_ZERO_OUTPUT_DISABLED;
-        const uint PACK_INTF_SEL = p_pacr::TWO_INTFS_ACTIVE;
-        //TTI_PACR(p_pacr::CFG_CTXT_0, p_pacr::NO_ROW_PAD_ZERO, p_pacr::DST_ACCESS_STRIDED_MODE, ADDR_MOD_2, p_pacr::ADDR_CNT_CTXT_0, ZERO_OUTPUT_FLAG, PACK_INTF_SEL, 0, 0, p_pacr::NO_CTXT_CTRL, 0, 1); // close block
     }
 
     TT_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0101); //reset z counters

--- a/llk_lib/llk_unpack_tilize.h
+++ b/llk_lib/llk_unpack_tilize.h
@@ -78,7 +78,7 @@ inline void _llk_unpack_tilize_init_(const std::uint32_t unpack_src_format=0, co
     //Force x-dim to 1024
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>(0 | (Tile_x_dim<<16));
     //Force z-dim to CNT_ZDIM/4
-    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32+1, 0, 0xffff0000>(0 | (Tile_z_dim<<16));
+    //cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32+1, 0, 0xffff0000>(0 | (Tile_z_dim<<16));
 
     //Force x-end for Unpackers to 1024
     TTI_SETADCXX(p_setadc::UNP0, 1023, 0x0);

--- a/llk_lib/llk_unpack_tilize.h
+++ b/llk_lib/llk_unpack_tilize.h
@@ -77,8 +77,8 @@ inline void _llk_unpack_tilize_init_(const std::uint32_t unpack_src_format=0, co
     cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(Tile_x_dim | (Tile_x_dim << 16));
     //Force x-dim to 1024
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32, 0, 0xffff0000>(0 | (Tile_x_dim<<16));
-    //Force z-dim to CNT_ZDIM/4
-    //cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32+1, 0, 0xffff0000>(0 | (Tile_z_dim<<16));
+    //Force z-dim to 1 as X dim is set to cover the entire tile, so no need to iterate over faces.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32+1, 0, 0xffff0000>(0 | (Tile_z_dim<<16));
 
     //Force x-end for Unpackers to 1024
     TTI_SETADCXX(p_setadc::UNP0, 1023, 0x0);


### PR DESCRIPTION
PACKER had 2 bugs for tilize and untilize operations:

- In tilize, block was closed after half a tile, leading to PACKER latching a new L1 address when it shouldn't have.

- In untilize PACKER had an extra PACR instruction. Since packing was done row wise, it caused the row in memory after a tile to be written, which in some kernels caused the next tile to have wrong first row.

Additional small code cleanups and fixes.