### PR TITLE
#15744: Emable FP32 for Reduce Scalar

### DIFF
--- a/llk_lib/llk_math_reduce.h
+++ b/llk_lib/llk_math_reduce.h
@@ -191,8 +191,6 @@ inline void _llk_math_reduce_(const uint dst_index, bool narrow_tile = false, co
         }
 
     } else if constexpr (dim == ReduceDim::REDUCE_SCALAR) {
-        //fp32 dest unsupported with reduce scalar, must fix zeroacc
-        static_assert(!is_fp32_dest_acc_en);
         for (int tile = 0; tile < 3; tile++) {
             // Wait and pool
             if constexpr (type == PoolType::MAX) {


### PR DESCRIPTION
Enabler PR for [#15744](https://github.com/tenstorrent/tt-metal/issues/15744) - we can remove assert for reduce scalar the same way it's done for Wormhole. I have temporarily enabled ```TensixComputeReduceHWShortInit``` and the test passes:

```
[ RUN      ] DeviceFixture.TensixComputeReduceHWShortInit
                 Device | INFO     | Opening user mode device driver
  Detecting chips (found 1)                                                                                                                                                                                                                                                                                                                                                                                                                     
2024-12-05 17:41:48.901 | WARNING  | SiliconDriver   - Unknown board type for chip 0. This might happen because chip is running old firmware. Defaulting to DEFAULT
2024-12-05 17:41:48.901 | WARNING  | SiliconDriver   - Unknown board type for chip 0. This might happen because chip is running old firmware. Defaulting to DEFAULT
2024-12-05 17:41:48.902 | INFO     | SiliconDriver   - Detected 1 PCI device : [0]
2024-12-05 17:41:48.902 | INFO     | SiliconDriver   - Opened PCI device 0; KMD version: 1.29.0
                  Metal | INFO     | Initializing device 0. Program cache is NOT enabled
                 Device | INFO     | For Blackhole hardcode AICLK to 800 MHz due to lack of ARC message support
                  Metal | INFO     | AI CLK for device 0 is:   800 MHz
                 Always | WARNING  | Dispatch Core Type = CoreType::WORKER
                  Metal | INFO     | DPRINT enabled on device 0, worker core (x=0,y=0) (physical (x=1,y=2)).
                  Metal | INFO     | DPRINT Server attached device 0
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = LoFi, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi2, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi3, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::SUM, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::AVG, FP32DestAcc = false, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = true, DstSyncFull = false, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = true, at_start = false
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = true
                   Test | INFO     | MathFid = HiFi4, ReduceType = ReduceType::MAX, FP32DestAcc = false, DstSyncFull = false, at_start = false
                  Metal | INFO     | Closing device 0
                  Metal | INFO     | DPRINT Server dettached device 0
                  Metal | INFO     | Disabling and clearing program cache on device 0
[       OK ] DeviceFixture.TensixComputeReduceHWShortInit (19857 ms)
[----------] 1 test from DeviceFixture (19857 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (19857 ms total)
[  PASSED  ] 1 test.
```