### PR TITLE
#16679: K min values support for TopK

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -407,7 +407,7 @@ inline void _bitonic_topk_merge(const int m_iter, const int k)
             while (datums_compared < total_datums_to_compare) {
                 for (uint ii=0; ii<inner_d; ii++) {
                     bitonic_topk_load8(dst_offset, ld_dist);
-                    TT_SFPSWAP(0, !idir ? p_sfpu::LREG0 : p_sfpu::LREG1, !idir ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+                    TTI_SFPSWAP(0, !idir ? p_sfpu::LREG0 : p_sfpu::LREG1, !idir ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
                     bitonic_topk_store8(dst_offset, ld_dist);
                     datums_compared += 8;
                     if (ii == (inner_d-1)) {

--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -115,7 +115,7 @@ inline void bitonic_topk_ph3_st4_to_1(bool dir, bool &init_replay, int replay_st
     
     if (dir == (bool)SortDir::ArgMin) {
         TT_LOG("Issue max/min reverse");
-        TTI_SFPCONFIG(0x104, 0xF, 1);      // Reverse the max/min behaviour of SWAP 0b0001 0000 0100
+        TTI_SFPCONFIG(0x104, 0xF, 1);      // Reverse the max/min behaviour of SWAP
         TTI_SFPNOP;
         TTI_SFPNOP;
     }

--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -115,7 +115,7 @@ inline void bitonic_topk_ph3_st4_to_1(bool dir, bool &init_replay, int replay_st
     
     if (dir == (bool)SortDir::ArgMin) {
         TT_LOG("Issue max/min reverse");
-        TTI_SFPCONFIG(0x104, 0xF, 1);      // Reverse the max/min behaviour of SWAP
+        TTI_SFPCONFIG(0x104, 0xF, 1);      // Reverse the max/min behaviour of SWAP 0b0001 0000 0100
         TTI_SFPNOP;
         TTI_SFPNOP;
     }
@@ -389,7 +389,7 @@ inline void _bitonic_topk_phases_steps(
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _bitonic_topk_merge(const int m_iter, const int k)
+inline void _bitonic_topk_merge(const bool idir, const int m_iter, const int k)
 {
     uint dst_addr_offset = 0;
     for (int face=0; face<2; face++) {
@@ -407,7 +407,7 @@ inline void _bitonic_topk_merge(const int m_iter, const int k)
             while (datums_compared < total_datums_to_compare) {
                 for (uint ii=0; ii<inner_d; ii++) {
                     bitonic_topk_load8(dst_offset, ld_dist);
-                    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+                    TT_SFPSWAP(0, !idir ? p_sfpu::LREG0 : p_sfpu::LREG1, !idir ? p_sfpu::LREG1 : p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
                     bitonic_topk_store8(dst_offset, ld_dist);
                     datums_compared += 8;
                     if (ii == (inner_d-1)) {

--- a/common/inc/sfpu/ckernel_sfpu_topk.h
+++ b/common/inc/sfpu/ckernel_sfpu_topk.h
@@ -388,8 +388,8 @@ inline void _bitonic_topk_phases_steps(
     topk_replay_init = -1;
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void _bitonic_topk_merge(const bool idir, const int m_iter, const int k)
+template <bool APPROXIMATION_MODE, bool idir, int ITERATIONS>
+inline void _bitonic_topk_merge(const int m_iter, const int k)
 {
     uint dst_addr_offset = 0;
     for (int face=0; face<2; face++) {


### PR DESCRIPTION
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/16679)

Ckernel updated to place min values into register instead of max values when flag is set, returning k min values as a result.

[Blackhole post commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/12896203386)