### PR TITLE
Update sfpu quant to support 2's complement Dest

### DIFF
--- a/common/inc/sfpu/ckernel_sfpu_quant.h
+++ b/common/inc/sfpu/ckernel_sfpu_quant.h
@@ -17,7 +17,7 @@ namespace ckernel
 namespace sfpu
 {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool SIGN_MAGNITUDE_FORMAT>
 inline void _quant_int32_(const uint dst_offset)
 {
     // Operand A is input (fp32)
@@ -37,12 +37,17 @@ inline void _quant_int32_(const uint dst_offset)
         // fp32->int8, descale value is zero (LREG_9)
         TTI_SFP_STOCH_RND(0,0,9,0,0,3);
         // LREG_0 -> dest as int32
-        TTI_SFPSTORE(0,4,ADDR_MOD_7,0);
+        if constexpr (SIGN_MAGNITUDE_FORMAT == false) {
+            TTI_SFPCAST(0, 4, InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP);
+            // Required after cast due to a bug in Blackhole RTL.
+            TTI_SFPSETSGN (0, 4, 0, 0);
+        }
+        TTI_SFPSTORE(0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
         dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool SIGN_MAGNITUDE_FORMAT>
 inline void _requant_int32_(const uint dst_offset)
 {
     // Operand A is input to requant (int32)
@@ -53,7 +58,12 @@ inline void _requant_int32_(const uint dst_offset)
     for (int d = 0; d < ITERATIONS; d++)
     {
         // operand A - int32
-        TTI_SFPLOAD(0, 4, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
+        if constexpr (SIGN_MAGNITUDE_FORMAT == false) {
+            TTI_SFPCAST(0, 4, InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP);
+            // Required after cast due to a bug in Blackhole RTL.
+            TTI_SFPSETSGN(0, 4, 0, 0);
+        }
         // operand B - fp32 scaler
         TT_SFPLOAD(1, 3, ADDR_MOD_7, dst_offset*64);
         // cast int32->fp32
@@ -65,12 +75,17 @@ inline void _requant_int32_(const uint dst_offset)
         // fp32->int8, descale value is zero (LREG_9)
         TTI_SFP_STOCH_RND(0,0,9,0,0,3);
         // LREG_0 -> dest as int32
-        TTI_SFPSTORE(0,4,ADDR_MOD_7,0);
+        if constexpr (SIGN_MAGNITUDE_FORMAT == false) {
+            TTI_SFPCAST(0, 4, InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP);
+            // Required after cast due to a bug in Blackhole RTL.
+            TTI_SFPSETSGN (0, 4, 0, 0);
+        }
+        TTI_SFPSTORE(0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
         dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool SIGN_MAGNITUDE_FORMAT>
 inline void _dequant_int32_(const uint dst_offset)
 {
     // Operand A[LREG0] is input to dequant (int32)
@@ -80,7 +95,12 @@ inline void _dequant_int32_(const uint dst_offset)
     #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         // operand A - int32
-        TTI_SFPLOAD(0, 4, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(0, InstrModLoadStore::INT32_2S_COMP, ADDR_MOD_7, 0);
+        if constexpr (SIGN_MAGNITUDE_FORMAT == false) {
+            TTI_SFPCAST(0, 4, InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP);
+            // Required after cast due to a bug in Blackhole RTL.
+            TTI_SFPSETSGN(0, 4, 0, 0);
+        }
         // operand B - fp32 scaler
         TT_SFPLOAD(1, 3, ADDR_MOD_7, dst_offset*64);
         // cast int32->fp32


### PR DESCRIPTION
tt-metal uses 2's complement for int32 values, so SFPU LOAD/STORE formats need to be updated to uplift Quant ops